### PR TITLE
Adding undefined check for swagger params in log

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,11 @@ swaggerTools.initializeMiddleware(swaggerDoc, function (middleware) {
                 statusCode = 400;
                 errMessage = err;
             }
-            console.log("[ERROR at " + new Date() + "]\n- "  + JSON.stringify(err) + "\n- req.params:" + JSON.stringify(req.swagger.params) );
+            if (req.swagger) {
+                console.log("[ERROR at " + new Date() + "]\n- "  + JSON.stringify(err) + "\n- req.params:" + JSON.stringify(req.swagger.params) );
+            } else {
+                console.log("[ERROR at " + new Date() + "]\n- "  + JSON.stringify(err) + "\n- req.params: No swagger params" );
+            }
             res.setHeader('Content-Type', 'text/html; charset=utf-8');
             res.statusCode = statusCode;
             res.end(JSON.stringify({"statusCode":statusCode, "message":errMessage}));


### PR DESCRIPTION
This logging bug appeared in some cases when a REST operation ended in error, this pull request will resolve the logging issue, by verifying that the swagger property is defined before trying to log its content.

Now we will have detailed logs for all REST operations that have some kind of error.

No functional issues were reported, so the failed ones may have been caused by bad requests, no permissions, etc. If any new thing arises, the log will help to identify any issue.